### PR TITLE
Fix DynamoDB checkpointer scan error hanlding

### DIFF
--- a/clientlibrary/checkpoint/dynamodb-checkpointer.go
+++ b/clientlibrary/checkpoint/dynamodb-checkpointer.go
@@ -441,6 +441,11 @@ func (checkpointer *DynamoCheckpoint) syncLeases(shardStatus map[string]*par.Sha
 	}
 
 	scanOutput, err := checkpointer.svc.Scan(context.TODO(), input)
+	if err != nil {
+		log.Debugf("Error performing SyncLeases. Error: %+v ", err)
+		return err
+	}
+
 	results := scanOutput.Items
 	for _, result := range results {
 		shardId, foundShardId := result[LeaseKeyKey]
@@ -456,10 +461,6 @@ func (checkpointer *DynamoCheckpoint) syncLeases(shardStatus map[string]*par.Sha
 		}
 	}
 
-	if err != nil {
-		log.Debugf("Error performing SyncLeases. Error: %+v ", err)
-		return err
-	}
 	log.Debugf("Lease sync completed. Next lease sync will occur in %s", time.Duration(checkpointer.kclConfig.LeaseSyncingTimeIntervalMillis)*time.Millisecond)
 	return nil
 }


### PR DESCRIPTION
The PR fixes panic in DynamoDB checkpointer caused by nil pointer dereference:  

```
    /go/pkg/mod/github.com/vmware/vmware-go-kcl-v2@v0.0.0-20220107022458-c862165130e7/clientlibrary/worker/worker.go:127 +0x217
created by github.com/vmware/vmware-go-kcl-v2/clientlibrary/worker.(*Worker).Start
	/go/pkg/mod/github.com/vmware/vmware-go-kcl-v2@v0.0.0-20220107022458-c862165130e7/clientlibrary/worker/worker.go:130 +0x5b
github.com/vmware/vmware-go-kcl-v2/clientlibrary/worker.(*Worker).Start.func1()
	/go/pkg/mod/github.com/vmware/vmware-go-kcl-v2@v0.0.0-20220107022458-c862165130e7/clientlibrary/worker/worker.go:361 +0xb31
github.com/vmware/vmware-go-kcl-v2/clientlibrary/worker.(*Worker).eventLoop(0xc00062c580)
	/go/pkg/mod/github.com/vmware/vmware-go-kcl-v2@v0.0.0-20220107022458-c862165130e7/clientlibrary/worker/worker.go:380 +0x68
github.com/vmware/vmware-go-kcl-v2/clientlibrary/worker.(*Worker).rebalance(0xc00062c580)
	/go/pkg/mod/github.com/vmware/vmware-go-kcl-v2@v0.0.0-20220107022458-c862165130e7/clientlibrary/checkpoint/dynamodb-checkpointer.go:341 +0x3b
github.com/vmware/vmware-go-kcl-v2/clientlibrary/checkpoint.(*DynamoCheckpoint).ListActiveWorkers(0xc000402690, 0x1?)
	/go/pkg/mod/github.com/vmware/vmware-go-kcl-v2@v0.0.0-20220107022458-c862165130e7/clientlibrary/checkpoint/dynamodb-checkpointer.go:444 +0x2f3
github.com/vmware/vmware-go-kcl-v2/clientlibrary/checkpoint.(*DynamoCheckpoint).syncLeases(0xc000402690, 0xc0007292e0?)
goroutine 506 [running]:

[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x15be773]
```