### PR TITLE
fix: catch DynamoDB Scan error when trying to scan nonexistent table or index

### DIFF
--- a/clientlibrary/checkpoint/checkpointer.go
+++ b/clientlibrary/checkpoint/checkpointer.go
@@ -20,7 +20,7 @@
 // Package checkpoint
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/checkpoint/checkpointer.go
+++ b/clientlibrary/checkpoint/checkpointer.go
@@ -20,7 +20,7 @@
 // Package checkpoint
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/checkpoint/dynamodb-checkpointer.go
+++ b/clientlibrary/checkpoint/dynamodb-checkpointer.go
@@ -20,7 +20,7 @@
 // Package checkpoint
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/checkpoint/dynamodb-checkpointer.go
+++ b/clientlibrary/checkpoint/dynamodb-checkpointer.go
@@ -20,7 +20,7 @@
 // Package checkpoint
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //
@@ -441,6 +441,12 @@ func (checkpointer *DynamoCheckpoint) syncLeases(shardStatus map[string]*par.Sha
 	}
 
 	scanOutput, err := checkpointer.svc.Scan(context.TODO(), input)
+
+	if err != nil {
+		log.Debugf("Error performing DynamoDB Scan. Error: %+v ", err)
+		return err
+	}
+
 	results := scanOutput.Items
 	for _, result := range results {
 		shardId, foundShardId := result[LeaseKeyKey]

--- a/clientlibrary/checkpoint/mock-dynamodb_test.go
+++ b/clientlibrary/checkpoint/mock-dynamodb_test.go
@@ -19,7 +19,7 @@
 
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/checkpoint/mock-dynamodb_test.go
+++ b/clientlibrary/checkpoint/mock-dynamodb_test.go
@@ -19,7 +19,7 @@
 
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/metrics/cloudwatch/cloudwatch.go
+++ b/clientlibrary/metrics/cloudwatch/cloudwatch.go
@@ -20,7 +20,7 @@
 // Package cloudwatch
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/metrics/cloudwatch/cloudwatch.go
+++ b/clientlibrary/metrics/cloudwatch/cloudwatch.go
@@ -20,7 +20,7 @@
 // Package cloudwatch
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -20,7 +20,7 @@
 // Package metrics
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -20,7 +20,7 @@
 // Package metrics
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/metrics/prometheus/prometheus.go
+++ b/clientlibrary/metrics/prometheus/prometheus.go
@@ -20,7 +20,7 @@
 // Package prometheus
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/metrics/prometheus/prometheus.go
+++ b/clientlibrary/metrics/prometheus/prometheus.go
@@ -20,7 +20,7 @@
 // Package prometheus
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/partition/partition.go
+++ b/clientlibrary/partition/partition.go
@@ -20,7 +20,7 @@
 // Package partition
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/partition/partition.go
+++ b/clientlibrary/partition/partition.go
@@ -20,7 +20,7 @@
 // Package partition
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/worker/polling-shard-consumer.go
+++ b/clientlibrary/worker/polling-shard-consumer.go
@@ -20,7 +20,7 @@
 // Package worker
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/worker/polling-shard-consumer.go
+++ b/clientlibrary/worker/polling-shard-consumer.go
@@ -20,7 +20,7 @@
 // Package worker
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -20,7 +20,7 @@
 // Package worker
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// # Copyright 2018 Patrick robinson
+// Copyright 2018 Patrick robinson.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -20,7 +20,7 @@
 // Package worker
 // The implementation is derived from https://github.com/patrobinson/gokini
 //
-// Copyright 2018 Patrick robinson
+// # Copyright 2018 Patrick robinson
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //
@@ -49,9 +49,9 @@ import (
 	par "github.com/vmware/vmware-go-kcl-v2/clientlibrary/partition"
 )
 
-//Worker is the high level class that Kinesis applications use to start processing data. It initializes and oversees
-//different components (e.g. syncing shard and lease information, tracking shard assignments, and processing data from
-//the shards).
+// Worker is the high level class that Kinesis applications use to start processing data. It initializes and oversees
+// different components (e.g. syncing shard and lease information, tracking shard assignments, and processing data from
+// the shards).
 type Worker struct {
 	streamName  string
 	regionName  string

--- a/logger/zap/zap.go
+++ b/logger/zap/zap.go
@@ -44,7 +44,6 @@ type ZapLogger struct {
 //
 // Base zap logger can be convert to SugaredLogger by calling to add a wrapper:
 // sugaredLogger := log.Sugar()
-//
 func NewZapLogger(logger *uzap.SugaredLogger) logger.Logger {
 	return &ZapLogger{
 		sugaredLogger: logger,


### PR DESCRIPTION
When trying to integrate the vmware-go-kcl-v2 within one of our codebases a bug was identified by our one of our end to end tests that causes for a nil pointer error. This occurs when the rebalance() function is called when no checkpoint has been set for any of the shards so when syncLeases() is called the dynamoDB scan will return a scanOutput.items which is nil causing for the nil pointer error. This can be avoided if we check for any errors returned from the checkpointer.svc.Scan() call. According to the AWS [documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html#API_Scan_Errors), the case being described will return a ResourceNotFoundExceptionerror  which can now be caught and the function can return with the error with this fix.  