### PR TITLE
fix: add DeleteMetricMillisBehindLatest for error case

### DIFF
--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -35,6 +35,7 @@ type MonitoringService interface {
 	IncrRecordsProcessed(shard string, count int)
 	IncrBytesProcessed(shard string, count int64)
 	MillisBehindLatest(shard string, milliSeconds float64)
+	DeleteMetricMillisBehindLatest(shard string)
 	LeaseGained(shard string)
 	LeaseLost(shard string)
 	LeaseRenewed(shard string)
@@ -53,6 +54,7 @@ func (NoopMonitoringService) Shutdown()                 {}
 func (NoopMonitoringService) IncrRecordsProcessed(_ string, _ int)         {}
 func (NoopMonitoringService) IncrBytesProcessed(_ string, _ int64)         {}
 func (NoopMonitoringService) MillisBehindLatest(_ string, _ float64)       {}
+func (NoopMonitoringService) DeleteMetricMillisBehindLatest(_ string)      {}
 func (NoopMonitoringService) LeaseGained(_ string)                         {}
 func (NoopMonitoringService) LeaseLost(_ string)                           {}
 func (NoopMonitoringService) LeaseRenewed(_ string)                        {}

--- a/clientlibrary/metrics/prometheus/prometheus.go
+++ b/clientlibrary/metrics/prometheus/prometheus.go
@@ -147,6 +147,10 @@ func (p *MonitoringService) MillisBehindLatest(shard string, millSeconds float64
 	p.behindLatestMillis.With(prom.Labels{"shard": shard, "kinesisStream": p.streamName}).Set(millSeconds)
 }
 
+func (p *MonitoringService) DeleteMetricMillisBehindLatest(shard string) {
+	p.behindLatestMillis.Delete(prom.Labels{"shard": shard, "kinesisStream": p.streamName})
+}
+
 func (p *MonitoringService) LeaseGained(shard string) {
 	p.leasesHeld.With(prom.Labels{"shard": shard, "kinesisStream": p.streamName, "workerID": p.workerID}).Inc()
 }

--- a/clientlibrary/worker/common-shard-consumer.go
+++ b/clientlibrary/worker/common-shard-consumer.go
@@ -51,7 +51,7 @@ type commonShardConsumer struct {
 }
 
 // Cleanup the internal lease cache
-func (sc *commonShardConsumer) releaseLease() {
+func (sc *commonShardConsumer) releaseLease(shard string) {
 	log := sc.kclConfig.Logger
 	log.Infof("Release lease for shard %s", sc.shard.ID)
 	sc.shard.SetLeaseOwner("")
@@ -63,6 +63,7 @@ func (sc *commonShardConsumer) releaseLease() {
 	}
 
 	// reporting lease lose metrics
+	sc.mService.DeleteMetricMillisBehindLatest(shard)
 	sc.mService.LeaseLost(sc.shard.ID)
 }
 

--- a/clientlibrary/worker/fan-out-shard-consumer.go
+++ b/clientlibrary/worker/fan-out-shard-consumer.go
@@ -46,7 +46,7 @@ type FanOutShardConsumer struct {
 // getRecords subscribes to a shard and reads events from it.
 // Precondition: it currently has the lease on the shard.
 func (sc *FanOutShardConsumer) getRecords() error {
-	defer sc.releaseLease()
+	defer sc.releaseLease(sc.shard.ID)
 
 	log := sc.kclConfig.Logger
 

--- a/clientlibrary/worker/polling-shard-consumer.go
+++ b/clientlibrary/worker/polling-shard-consumer.go
@@ -79,7 +79,7 @@ func (sc *PollingShardConsumer) getShardIterator() (*string, error) {
 // getRecords continuously poll one shard for data record
 // Precondition: it currently has the lease on the shard.
 func (sc *PollingShardConsumer) getRecords() error {
-	defer sc.releaseLease()
+	defer sc.releaseLease(sc.shard.ID)
 
 	log := sc.kclConfig.Logger
 


### PR DESCRIPTION
In case of error when getting records there is a need to delete the MillisBehindLatest metric for the specific shard to eliminate inconsistencies with logging the metric. Returning at this point effectively releases the lease for the shard and hence the lease can be potentially acquired by other consumers in the system (Could be from the same pod or
 other pods). If the lease is acquired by another consumer in a different pod this metric would continue
to be collected for this shard from the same pod as well as the new pod. To prevent such a situation
delete the metric from this pod so that it is correctly collected.