### PR TITLE
Info level is too chatty for this sleep message, debug is good

### DIFF
--- a/clientlibrary/worker/polling-shard-consumer.go
+++ b/clientlibrary/worker/polling-shard-consumer.go
@@ -176,12 +176,12 @@ func (sc *PollingShardConsumer) getRecords() error {
 				continue
 			}
 			if err == localTPSExceededError {
-				log.Infof("localTPSExceededError so sleep for a second")
+				log.Debugf("localTPSExceededError so sleep for a second")
 				sc.waitASecond(sc.currTime)
 				continue
 			}
 			if err == maxBytesExceededError {
-				log.Infof("maxBytesExceededError so sleep for %+v seconds", coolDownPeriod)
+				log.Debugf("maxBytesExceededError so sleep for %+v seconds", coolDownPeriod)
 				time.Sleep(time.Duration(coolDownPeriod) * time.Second)
 				continue
 			}


### PR DESCRIPTION
Having this in Info level produces thousands of messages per minute in a production level stream that is operating appropriately. Knowing this for debug purposes is good enough. We shouldn't be overloading log processing pipelines with this much repetitive spam in info level.

Resolves https://github.com/vmware/vmware-go-kcl-v2/issues/40