### PR TITLE
Info level is too chatty for this sleep message, debug is good with new metrics to show when retries and errors happen

### DIFF
--- a/clientlibrary/metrics/interfaces.go
+++ b/clientlibrary/metrics/interfaces.go
@@ -41,6 +41,10 @@ type MonitoringService interface {
 	LeaseRenewed(shard string)
 	RecordGetRecordsTime(shard string, time float64)
 	RecordProcessRecordsTime(shard string, time float64)
+	IncrLocalTPSBackoffs(shard string, count int)
+	IncrMaxBytesBackoffs(shard string, count int)
+	IncrThrottlingBackoffs(shard string, count int)
+	IncrGetRecordsErrors(shard string, count int)
 	Shutdown()
 }
 
@@ -60,3 +64,7 @@ func (NoopMonitoringService) LeaseLost(_ string)                           {}
 func (NoopMonitoringService) LeaseRenewed(_ string)                        {}
 func (NoopMonitoringService) RecordGetRecordsTime(_ string, _ float64)     {}
 func (NoopMonitoringService) RecordProcessRecordsTime(_ string, _ float64) {}
+func (NoopMonitoringService) IncrLocalTPSBackoffs(_ string, _ int)         {}
+func (NoopMonitoringService) IncrMaxBytesBackoffs(_ string, _ int)         {}
+func (NoopMonitoringService) IncrThrottlingBackoffs(_ string, _ int)       {}
+func (NoopMonitoringService) IncrGetRecordsErrors(_ string, _ int)         {}

--- a/clientlibrary/worker/polling-shard-consumer.go
+++ b/clientlibrary/worker/polling-shard-consumer.go
@@ -32,9 +32,10 @@ package worker
 import (
 	"context"
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"math"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
@@ -53,10 +54,10 @@ const (
 )
 
 var (
-	rateLimitTimeNow      = time.Now
-	rateLimitTimeSince    = time.Since
-	localTPSExceededError = errors.New("Error GetRecords TPS Exceeded")
-	maxBytesExceededError = errors.New("Error GetRecords Max Bytes For Call Period Exceeded")
+	rateLimitTimeNow    = time.Now
+	rateLimitTimeSince  = time.Since
+	errLocalTPSExceeded = errors.New("error GetRecords TPS exceeded")
+	errMaxBytesExceeded = errors.New("error GetRecords max bytes for call period exceeded")
 )
 
 // PollingShardConsumer is responsible for polling data records from a (specified) shard.
@@ -175,13 +176,15 @@ func (sc *PollingShardConsumer) getRecords() error {
 				sc.waitASecond(sc.currTime)
 				continue
 			}
-			if err == localTPSExceededError {
-				log.Infof("localTPSExceededError so sleep for a second")
+			if err == errLocalTPSExceeded {
+				log.Debugf("localTPSExceededError so sleep for a second")
+				sc.mService.IncrLocalTPSBackoffs(sc.shard.ID, 1)
 				sc.waitASecond(sc.currTime)
 				continue
 			}
-			if err == maxBytesExceededError {
-				log.Infof("maxBytesExceededError so sleep for %+v seconds", coolDownPeriod)
+			if err == errMaxBytesExceeded {
+				log.Debugf("maxBytesExceededError so sleep for %+v seconds", coolDownPeriod)
+				sc.mService.IncrMaxBytesBackoffs(sc.shard.ID, 1)
 				time.Sleep(time.Duration(coolDownPeriod) * time.Second)
 				continue
 			}
@@ -199,9 +202,11 @@ func (sc *PollingShardConsumer) getRecords() error {
 				}
 				// exponential backoff
 				// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.RetryAndBackoff
+				sc.mService.IncrThrottlingBackoffs(sc.shard.ID, 1)
 				time.Sleep(time.Duration(math.Exp2(float64(retriedErrors))*100) * time.Millisecond)
 				continue
 			}
+			sc.mService.IncrGetRecordsErrors(sc.shard.ID, 1)
 			log.Errorf("Error getting records from Kinesis that cannot be retried: %+v Request: %s", err, getRecordsArgs)
 			return err
 		}
@@ -264,7 +269,7 @@ func (sc *PollingShardConsumer) checkCoolOffPeriod() (int, error) {
 		if sc.bytesRead%MaxBytesPerSecond > 0 {
 			coolDown++
 		}
-		return coolDown, maxBytesExceededError
+		return coolDown, errMaxBytesExceeded
 	} else {
 		sc.remBytes -= sc.bytesRead
 	}
@@ -285,7 +290,7 @@ func (sc *PollingShardConsumer) callGetRecordsAPI(gri *kinesis.GetRecordsInput) 
 	}
 
 	if sc.callsLeft < 1 {
-		return nil, 0, localTPSExceededError
+		return nil, 0, errLocalTPSExceeded
 	}
 	getResp, err := sc.kc.GetRecords(context.TODO(), gri)
 	sc.callsLeft--

--- a/clientlibrary/worker/polling-shard-consumer_test.go
+++ b/clientlibrary/worker/polling-shard-consumer_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	testGetRecordsError = errors.New("GetRecords Error")
+	errTestGetRecords = errors.New("GetRecords error")
 )
 
 func TestCallGetRecordsAPI(t *testing.T) {
@@ -62,7 +62,7 @@ func TestCallGetRecordsAPI(t *testing.T) {
 	}
 	out2, _, err2 := psc2.callGetRecordsAPI(&gri)
 	assert.Nil(t, out2)
-	assert.ErrorIs(t, err2, localTPSExceededError)
+	assert.ErrorIs(t, err2, errLocalTPSExceeded)
 	m2.AssertExpectations(t)
 
 	// check that getRecords is called normally in bytesRead = 0 case
@@ -162,7 +162,7 @@ func TestCallGetRecordsAPI(t *testing.T) {
 	// case where getRecords throws error
 	m7 := MockKinesisSubscriberGetter{}
 	ret7 := kinesis.GetRecordsOutput{Records: nil}
-	m7.On("GetRecords", mock.Anything, mock.Anything, mock.Anything).Return(&ret7, testGetRecordsError)
+	m7.On("GetRecords", mock.Anything, mock.Anything, mock.Anything).Return(&ret7, errTestGetRecords)
 	psc7 := PollingShardConsumer{
 		commonShardConsumer: commonShardConsumer{kc: &m7},
 		callsLeft:           2,
@@ -172,7 +172,7 @@ func TestCallGetRecordsAPI(t *testing.T) {
 		return 2 * time.Second
 	}
 	out7, checkSleepVal7, err7 := psc7.callGetRecordsAPI(&gri)
-	assert.Equal(t, err7, testGetRecordsError)
+	assert.Equal(t, err7, errTestGetRecords)
 	assert.Equal(t, checkSleepVal7, 0)
 	assert.Equal(t, out7, &ret7)
 	m7.AssertExpectations(t)


### PR DESCRIPTION
Having this in Info level produces thousands of messages per minute in a production level stream that is operating appropriately. Knowing this for debug purposes is good enough. We shouldn't be overloading log processing pipelines with this much repetitive spam in info level. We can expose these details in metrics instead.

Resolves https://github.com/vmware/vmware-go-kcl-v2/issues/40

Also refactoring to satisfy `go-staticcheck`
![image](https://user-images.githubusercontent.com/3846175/233406724-9c0256c4-0d58-463e-bd95-8b04f8b45ba3.png)